### PR TITLE
Rename label `region` to `asserts_site`.

### DIFF
--- a/nodejs/src/lib/LambdaInstanceMetrics.ts
+++ b/nodejs/src/lib/LambdaInstanceMetrics.ts
@@ -23,7 +23,7 @@ export class LambdaInstanceMetrics {
         asserts_source: string;
         asserts_tenant?: string;
         tenant?: string;
-        region: string | undefined;
+        asserts_site: string | undefined;
     };
 
     private static singleton: LambdaInstanceMetrics = new LambdaInstanceMetrics();
@@ -73,7 +73,7 @@ export class LambdaInstanceMetrics {
             namespace: "AWS/Lambda",
             instance: hostname() + ":" + process.pid,
             asserts_source: 'prom-client',
-            region: process.env['AWS_REGION']
+            asserts_site: this.mapRegionCode(process.env['AWS_REGION'])
         };
         this.labelValues.function_name = process.env["AWS_LAMBDA_FUNCTION_NAME"];
         this.labelValues.job = process.env["AWS_LAMBDA_FUNCTION_NAME"];
@@ -126,5 +126,20 @@ export class LambdaInstanceMetrics {
 
     isNameAndVersionSet(): boolean {
         return !!(this.labelValues.job && this.labelValues.function_name && this.labelValues.version);
+    }
+
+    mapRegionCode(region: string | undefined) {
+        switch(region) {
+            case 'uswest1':
+                return 'us-west-1';
+            case 'uswest2':
+                return 'us-west-2';
+            case 'useast1':
+                return 'us-east-1';
+            case 'useast2':
+                return 'us-east-2';
+            default:
+                return region;
+        }
     }
 }

--- a/nodejs/tests/unit/LambdaInstanceMetric.test.ts
+++ b/nodejs/tests/unit/LambdaInstanceMetric.test.ts
@@ -27,7 +27,7 @@ describe("Metrics should have been initialized", () => {
         expect(lambdaInstance.labelValues).toBeTruthy();
         expect(lambdaInstance.labelValues.instance).toBeTruthy();
         expect(lambdaInstance.labelValues.namespace).toBe("AWS/Lambda");
-        expect(lambdaInstance.labelValues.region).toBe("us-west-2");
+        expect(lambdaInstance.labelValues.asserts_site).toBe("us-west-2");
         expect(lambdaInstance.labelValues.function_name).toBe("OrderProcessor")
         expect(lambdaInstance.labelValues.job).toBe("OrderProcessor")
         expect(lambdaInstance.labelValues.version).toBe("1");


### PR DESCRIPTION
[ch10542]

Rename label `region` to `asserts_site`.
Region values from AWS Environment variables are missing a `-`