### PR TITLE
Some minor changes and Tooling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # asserts-aws-lambda-layer-js
 
-AWS Lambda layer to capture NodeJS runtime metrics from a NodeJS AWS Lambda function. The layer uses [prom-client](https://github.com/siimon/prom-client) to capture the metrics and forwards them to a configured end point through a `https` `POST` method on api `/api/v1/import/prometheus`. The metrics are sent in prometheus text format
+AWS Lambda layer to capture NodeJS runtime metrics from a NodeJS AWS Lambda function. The layer
+uses [prom-client](https://github.com/siimon/prom-client) to capture the metrics and forwards them to a configured end
+point through a `https` `POST` method on api `/api/v1/import/prometheus`. The metrics are sent in prometheus text format
 
 # Programmatic instrumentation
 
@@ -8,11 +10,12 @@ If your Lambda code is written in TypeScript, you can include it in the `devDepe
 
 ```
 "devDependencies": {
-  "asserts-aws-lambda-layer": "1.0.0"
+  "asserts-aws-lambda-layer": "1"
 }
 ```
 
 In your Lambda Handler code
+
 ```
 import {wrapHandler} from 'asserts-aws-lambda-layer';
 
@@ -22,6 +25,7 @@ exports.handler = wrapHandler(async (event, context) => {
 ```
 
 # Automatic instrumentation without any code change
+
 For automatic instrumentation, the following environment variable needs to be defined in your Lambda function
 
 ```
@@ -29,11 +33,13 @@ NODE_OPTIONS = -r asserts-aws-lambda-layer/awslambda-auto
 ```
 
 # Environment variables for forwarding metrics to a prometheus end-point
-The following environment variables will have to be defined regardless of whether you use programmatic or automatic instrumentation
+
+The following environment variables will have to be defined regardless of whether you use programmatic or automatic
+instrumentation
 
 |Variable name| Description|
 |-------------|------------|
-|`ASSERTS_CLOUD_HOST`|An endpoint which can receive the `POST` method call on api `/api/v1/import/prometheus`. This can either be an asserts cloud endpoint or an end point exposed on the EC2 or ECS instance where [Asserts AWS Exporter](https://app.gitbook.com/o/-Mih12_HEHZ0gGyaqQ0X/s/-Mih17ZSkwF7P2VxUo4u/quickstart-guide/setting-up-aws-serverless-monitoring) is deployed |
+|`ASSERTS_METRICSTORE_HOST`|An endpoint which can receive the `POST` method call on api `/api/v1/import/prometheus`. This can either be an asserts cloud endpoint or an end point exposed on the EC2 or ECS instance where [Asserts AWS Exporter](https://app.gitbook.com/o/-Mih12_HEHZ0gGyaqQ0X/s/-Mih17ZSkwF7P2VxUo4u/quickstart-guide/setting-up-aws-serverless-monitoring) is deployed |
 |`ASSERTS_TENANT_NAME`|The tenant name in the Asserts Cloud where the metrics will be ingested |
 |`ASSERTS_PASSWORD`|If the endpoint supports and expects Basic authorization the credentials can be configured here |
 |`ASSERTS_LAYER_DISABLED`| If set to `true`, the layer will be disabled|
@@ -48,7 +54,8 @@ The following metrics are exported by this layer
 |`aws_lambda_errors_total`| `Counter` | The count of invocations on this Lambda instance that resulted in an error |
 |`aws_lambda_duration_seconds`| `Histogram` | A histogram of the duration of the invocations  |
 
-In addition to the above metrics, the default metrics collected by [prom-client](https://github.com/siimon/prom-client) are also exported.
+In addition to the above metrics, the default metrics collected by [prom-client](https://github.com/siimon/prom-client)
+are also exported.
 
 To build the layer,
 
@@ -62,11 +69,44 @@ rm tests/unit/*.js
 npm test
 npm pack
 ./build-layer.sh
-ls -al asserts-sdk*
--rw-r--r--  1 radhakrishnanj  staff  13736954 Jan 14 13:18 asserts-sdk-1.0.0.zip
+ls -al asserts-aws-lambda-layer-js*
+-rw-r--r--  1 radhakrishnanj  staff  13736954 Jan 14 13:18 asserts-aws-lambda-layer-js-1.zip
 ```
 
-The tools provider under `deployment/cdk` can be used to apply the lambda layer in your functions along with the various environment variables.
+To create a layer from the zip -
+
+* Create a s3 bucket as follows
+
+```
+aws cloudformation create-stack \\
+    --stack-name asserts-assets-s3-bucket \\
+    --template-body file://$PWD/deployment/cfn-asserts-assets-s3bucket.yml
+```
+
+* Upload the layer zip to this bucket
+
+```
+aws s3 cp asserts-aws-lambda-layer-js-1.zip s3://asserts-assets/asserts-aws-lambda-layer-js-1.zip
+```
+
+* Create a Layer using the S3 url
+
+```
+aws cloudformation create-stack \\
+    --stack-name asserts-aws-lambda-layer-js-1 \\
+    --template-body file://$PWD/cfn-asserts-lambda-layers.yml
+    --parameters ParameterKey=LayerS3Key,ParameterValue=s3://asserts-assets/asserts-aws-lambda-layer-js-1.zip
+```
+
+* To add the layer to your function `MyLambdaFunction`, copy the `deployment/sample-config.yml` as `config.yml`. Specify
+  the function name and layer ARN and other environment properties and run the `manage_asserts_layer` script
+
+```
+python manage_asserts_layer.py
+```
+
+
+
 
 
 

--- a/build-layer.sh
+++ b/build-layer.sh
@@ -1,3 +1,4 @@
+npm test
 npm pack
 mkdir -p build/LAYER/nodejs
 cp package-for-layer-build.json build/LAYER/nodejs/package.json
@@ -5,7 +6,7 @@ cd build/LAYER/nodejs
 npm install
 rm package.json
 cd ..
-zip -r asserts-sdk-1.0.0.zip nodejs
-mv asserts-sdk-1.0.0.zip ../..
+zip -r asserts-aws-lambda-layer-js-$VERSION.zip nodejs
+mv asserts-aws-lambda-layer-js-$VERSION.zip ../..
 cd ../..
 rm -fR build

--- a/deployment/cfn-asserts-assets-s3bucket.yml
+++ b/deployment/cfn-asserts-assets-s3bucket.yml
@@ -1,0 +1,10 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Creates a s3 bucket to keep all Asserts deployment assets
+Resources:
+  S3BucketForAsserts:
+    Type: AWS::S3::Bucket
+    Description: >-
+      A S3 bucket to host all Asserts assets
+    Properties:
+      BucketName: asserts-assets

--- a/deployment/cfn-asserts-lambda-layers.yml
+++ b/deployment/cfn-asserts-lambda-layers.yml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Asserts NodeJS Lambda Layer
+Parameters:
+  LayerS3Key:
+    Type: String
+    Description: Layer S3 Key. For e.g. asserts-aws-lambda-layer-js-1.zip where `1` is the version of the layer
+Resources:
+  AssertsNodeJSAWSLambdaLayer:
+    Type: AWS::Lambda::LayerVersion
+    Description: >-
+      Asserts AWS Lambda Layer for NodeJS Runtime that exports resource and invocation metrics in prometheus format
+      to the API endpoint /api/v1/import/prometheus on a configured host
+    Properties:
+      LayerName: asserts-aws-lambda-layer-js
+      CompatibleRuntimes:
+        - nodejs14.x
+      Content:
+        S3Bucket: asserts-assets
+        S3Key: !Ref LayerS3Key
+

--- a/deployment/manage_asserts_layer.py
+++ b/deployment/manage_asserts_layer.py
@@ -1,0 +1,201 @@
+import re
+import boto3
+import yaml
+
+# Get the Lambda Client
+lambda_client = boto3.client('lambda')
+
+file = open('config.yml', 'r')
+config = yaml.safe_load(file)
+if config is None:
+    print("Config file 'config.yml' is empty or parsing failed")
+    raise ()
+fn_name_pattern = config.get('function_name_pattern')
+specified_fn_names = config.get('function_names')
+operation = config.get('operation')
+layer_arn = config.get('layer_arn')
+
+if operation is None:
+    print("Config file 'config.yml' is invalid. 'operation' is not specified")
+    raise ()
+elif operation not in ['add-layer', 'disable-layer', 'enable-layer', 'remove-layer', 'update-env-variables',
+                       'update-version']:
+    print(
+        "Config file 'config.yml' is invalid. Invalid value '" + operation +
+        "' for 'operation'. Valid values are ['add-layer', 'disable-layer', 'enable-layer', 'remove-layer', "
+        "'update-env-variables', 'update-version']")
+    raise ()
+
+if specified_fn_names is None and fn_name_pattern is None:
+    print(
+        "Config file 'config.yml' is invalid. Either 'function_name_pattern' or 'function_names' should "
+        "be specified")
+    raise ()
+elif fn_name_pattern is not None:
+    specified_fn_name_pattern = re.compile(fn_name_pattern)
+
+if operation == 'add-layer' and layer_arn is None:
+    print("Config file 'config.yml' is invalid. 'layer_arn' needs to be specified for `add` operation")
+    raise ()
+
+variables = {
+    'NODE_OPTIONS': '-r asserts-aws-lambda-layer/awslambda-auto'
+}
+host = 'ASSERTS_METRICSTORE_HOST'
+tenant_name = 'ASSERTS_TENANT_NAME'
+password = 'ASSERTS_PASSWORD'
+
+if operation in 'add-layer' and config.get(host) is None:
+    print("Config file 'config.yml' is invalid. '" + host + "' is not specified")
+    raise ()
+
+if config.get(host) is not None:
+    variables['ASSERTS_METRICSTORE_HOST'] = config[host]
+if config.get(tenant_name) is not None:
+    variables['ASSERTS_TENANT_NAME'] = config[tenant_name]
+if config.get(password) is not None:
+    variables['ASSERTS_PASSWORD'] = config[password]
+
+
+def update_all_functions():
+    # List the functions
+    next_marker: str
+    fns = lambda_client.list_functions()
+    update_functions(fns)
+
+    next_marker = fns.get('NextMarker')
+    while next_marker is not None:
+        fns = lambda_client.list_functions(Marker=next_marker)
+        update_functions(fns)
+        next_marker = fns.get('NextMarker')
+
+
+def update_functions(fns):
+    for fn in fns['Functions']:
+        if fn['Runtime'] == 'nodejs14.x' and should_update_fn(fn):
+            if operation == 'add-layer':
+                add_layer(fn)
+            elif operation == 'remove-layer':
+                remove_layer(fn)
+            elif operation == 'disable-layer':
+                disable_layer(fn)
+            elif operation == 'enable-layer':
+                enable_layer(fn)
+            elif operation == 'update-env-variables':
+                update_config(fn)
+            else:
+                update_layer_version(fn)
+
+
+def should_update_fn(fn):
+    if specified_fn_names is not None:
+        return fn['FunctionName'] in specified_fn_names
+    else:
+        return specified_fn_name_pattern.match(fn['FunctionName'])
+
+
+def remove_layer(fn):
+    layers = get_layer_arns(fn)
+    asserts_layer = get_asserts_layer(fn)
+    if asserts_layer is not None:
+        layers.remove(asserts_layer)
+        current_variables = fn['Environment']['Variables']
+        asserts_properties = list(filter(lambda _key: 'ASSERTS_' in _key, current_variables.keys()))
+        for key in asserts_properties:
+            current_variables.pop(key)
+        current_variables.pop('NODE_OPTIONS')
+        update_fn(fn, {'Variables': current_variables}, layers)
+
+
+def disable_layer(fn):
+    if get_asserts_layer(fn) is not None:
+        current_variables = fn['Environment']['Variables']
+        current_variables['ASSERTS_LAYER_DISABLED'] = 'true'
+        update_fn(fn, {'Variables': current_variables}, None)
+
+
+def enable_layer(fn):
+    if get_asserts_layer(fn) is not None:
+        current_variables = fn['Environment']['Variables']
+        current_variables['ASSERTS_LAYER_DISABLED'] = 'false'
+        update_fn(fn, {'Variables': current_variables}, None)
+    return
+
+
+def add_layer(fn):
+    layers = get_layer_arns(fn)
+    layers.append(layer_arn)
+
+    _env = {'Variables': variables}
+    if fn.get('Environment') is not None:
+        merge_variables(_env, fn)
+
+    update_fn(fn, _env, layers)
+    return
+
+
+def update_config(fn):
+    _env = {'Variables': variables}
+    if get_asserts_layer(fn) is not None:
+        if fn.get('Environment') is not None:
+            merge_variables(_env, fn)
+        update_fn(fn, _env, None)
+        return
+    else:
+        print(fn['FunctionArn'] + ": does not have asserts lambda layer added")
+
+
+def update_layer_version(fn):
+    layers = []
+    if fn['Layers'] is not None:
+        layers = get_layer_arns(fn)
+    if get_asserts_layer(fn) is not None:
+        layers.remove(get_asserts_layer(fn))
+    layers.append(layer_arn)
+    update_fn(fn, None, layers)
+    return
+
+
+# See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.update_function_configuration
+def update_fn(fn, _env, layers):
+    if layers is not None and _env is not None:
+        lambda_client.update_function_configuration(
+            FunctionName=fn['FunctionName'],
+            Layers=layers,
+            Environment=_env
+        )
+    elif _env is None:
+        lambda_client.update_function_configuration(
+            FunctionName=fn['FunctionName'],
+            Layers=layers
+        )
+    else:
+        lambda_client.update_function_configuration(
+            FunctionName=fn['FunctionName'],
+            Environment=_env
+        )
+
+
+def merge_variables(_env, fn):
+    _variables = fn['Environment']['Variables']
+    _variables.update(variables)
+    _env['Variables'] = _variables
+
+
+def get_asserts_layer(fn):
+    layers = get_layer_arns(fn)
+
+    for layer in layers:
+        if "asserts-aws-lambda-layer" in layer:
+            return layer
+    return None
+
+
+def get_layer_arns(fn):
+    layers = []
+    if fn.get('Layers') is not None:
+        layers = list(map(lambda lyr: lyr['Arn'], fn['Layers']))
+    return layers
+
+
+update_all_functions()

--- a/deployment/sample-config.yml
+++ b/deployment/sample-config.yml
@@ -1,0 +1,16 @@
+# Supported operations are 'add-layer', 'update-version', 'update-env-variables', 'disable', 'enable'
+operation: add-layer
+
+# Layer arn needs to be specified for 'add' or 'update-version' operations
+layer_arn: arn:aws:lambda:us-west-2:342994379019:layer:asserts-aws-lambda-layer-js:2
+
+# ASSERTS_METRICSTORE_HOST and ASSERTS_TENANT_NAME are required for 'add' operation
+# ASSERTS_PASSWORD is optional
+ASSERTS_METRICSTORE_HOST: chief.tsdb.dev.asserts.ai
+ASSERTS_TENANT: chief
+ASSERTS_PASSWORD: wrong
+
+# Functions can be specified either through a regex pattern or through a list of function names
+# function_name_pattern: Sample.+
+function_names:
+  - Sample-Function

--- a/package-for-layer-build.json
+++ b/package-for-layer-build.json
@@ -1,9 +1,9 @@
 {
   "name": "build-AWS-layer",
-  "version": "1.0.0",
+  "version": "1",
   "description": "Asserts AWS Lambda Layer for NodeJS to push prometheus metrics",
   "main": "index.js",
   "dependencies": {
-    "asserts-aws-lambda-layer": "file:../../../asserts-aws-lambda-layer-1.0.0.tgz"
+    "asserts-aws-lambda-layer": "file:../../../asserts-aws-lambda-layer-1.tgz"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asserts-aws-lambda-layer",
-  "version": "0.1",
+  "version": "1",
   "description": "Asserts AWS Lambda Layer for NodeJS to push prometheus metrics",
   "main": "src/index.js",
   "files": [

--- a/src/lib/DynamicPatcher.ts
+++ b/src/lib/DynamicPatcher.ts
@@ -13,10 +13,14 @@ export class DynamicPatcher {
 
 
     patchHandler() {
-        console.log("Asserts Dynamic Handler Patching is enabled. Will try to patch handler dynamically");
         if (process.env.LAMBDA_TASK_ROOT && process.env.LAMBDA_TASK_ROOT !== "undefined") {
-            if (process.env._HANDLER && process.env._HANDLER !== "undefined" && !this.disabled) {
-                this.tryPatchHandler(process.env.LAMBDA_TASK_ROOT, process.env._HANDLER);
+            if (process.env._HANDLER && process.env._HANDLER !== "undefined") {
+                if (this.disabled) {
+                    console.log("Asserts Dynamic Handler Patching is disabled");
+                } else {
+                    console.log("Asserts Dynamic Handler Patching is enabled. Will try to patch handler dynamically");
+                    this.tryPatchHandler(process.env.LAMBDA_TASK_ROOT, process.env._HANDLER);
+                }
             } else {
                 console.log(`LAMBDA_TASK_ROOT is non-empty(${process.env.LAMBDA_TASK_ROOT}) but _HANDLER is not set`);
             }

--- a/src/lib/LambdaInstanceMetrics.ts
+++ b/src/lib/LambdaInstanceMetrics.ts
@@ -3,7 +3,7 @@ import {collectDefaultMetrics, Counter, Histogram, register as globalRegister} f
 import {hostname} from 'os';
 
 collectDefaultMetrics({
-    gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5], // These are the default buckets.
+    gcDurationBuckets: [0.001, 0.01, 0.1, 1, 2, 5, 10], // These are the default buckets.
 });
 
 export class LambdaInstanceMetrics {
@@ -64,7 +64,7 @@ export class LambdaInstanceMetrics {
         this.labelValues.function_name = process.env["AWS_LAMBDA_FUNCTION_NAME"];
         this.labelValues.job = process.env["AWS_LAMBDA_FUNCTION_NAME"];
         this.labelValues.version = process.env["AWS_LAMBDA_FUNCTION_VERSION"];
-        if(process.env["ASSERTS_ENVIRONMENT"]) {
+        if (process.env["ASSERTS_ENVIRONMENT"]) {
             this.labelValues.asserts_env = process.env["ASSERTS_ENVIRONMENT"];
         }
     }

--- a/tests/unit/RemoteWriter.test.ts
+++ b/tests/unit/RemoteWriter.test.ts
@@ -33,7 +33,7 @@ describe("Handler Wrapper works for async and sync", () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
-        process.env["ASSERTS_CLOUD_HOST"] = undefined;
+        process.env["ASSERTS_METRICSTORE_HOST"] = undefined;
         process.env["ASSERTS_TENANT_NAME"] = undefined;
         process.env["ASSERTS_PASSWORD"] = undefined;
     });
@@ -64,15 +64,15 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("Tenant name Missing", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "url";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "url";
         process.env["ASSERTS_PASSWORD"] = "tenantPassword";
 
         const remoteWriter: RemoteWriter = new RemoteWriter();
-        expect(remoteWriter.isRemoteWritingOn()).toBe(false);
+        expect(remoteWriter.isRemoteWritingOn()).toBe(true);
     });
 
     it("Password is treated as optional", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "url";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "url";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
 
         const remoteWriter: RemoteWriter = new RemoteWriter();
@@ -80,7 +80,7 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("All Config Present", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "url";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "url";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
         process.env["ASSERTS_PASSWORD"] = "tenantPassword";
 
@@ -97,7 +97,7 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("Flush calls remote write", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "url";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "url";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
         process.env["ASSERTS_PASSWORD"] = "tenantPassword";
 
@@ -115,7 +115,7 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("Test writeMetrics without password", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "host";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "host";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
 
         RemoteWriter.prototype.requestErrorHandler = mockedResponseErrorHandler;
@@ -151,7 +151,7 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("Test writeMetrics with password", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "host";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "host";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
         process.env["ASSERTS_PASSWORD"] = "tenantPassword";
 
@@ -190,7 +190,7 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("Test writeMetrics no metrics", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "url";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "url";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
         process.env["ASSERTS_PASSWORD"] = "tenantPassword";
 
@@ -225,7 +225,7 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("Test writeMetrics when writing cancelled", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "url";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "url";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
         process.env["ASSERTS_PASSWORD"] = "tenantPassword";
 
@@ -248,7 +248,7 @@ describe("Handler Wrapper works for async and sync", () => {
     });
 
     it("Test responseCallback", async () => {
-        process.env["ASSERTS_CLOUD_HOST"] = "url";
+        process.env["ASSERTS_METRICSTORE_HOST"] = "url";
         process.env["ASSERTS_TENANT_NAME"] = "tenantName";
         process.env["ASSERTS_PASSWORD"] = "tenantPassword";
 


### PR DESCRIPTION
[ch10547]
* Change env variable name for metric host
* AWS automatically versions layers as `1, 2, 3` so follow the same convention for versioning the layer releases. Layer version 3 in customer environment should correspond to release version 3 of the layer
* CloudFormation scripts to create Lambda layer for NodeJS given the layer zip file
* Python script to manage layers in Lambda. Supports `add/remove/update-version/update-env-variables/enable/disable`. Target functions can be specified through a list or regex pattern