### PR TITLE
Set `ASSERTS_ENVIRONMENT`

### DIFF
--- a/deployment/manage_asserts_layer.py
+++ b/deployment/manage_asserts_layer.py
@@ -44,6 +44,8 @@ variables = {
 host = 'ASSERTS_METRICSTORE_HOST'
 tenant_name = 'ASSERTS_TENANT_NAME'
 password = 'ASSERTS_PASSWORD'
+env = 'ASSERTS_ENVIRONMENT'
+site = 'ASSERTS_SITE'
 
 if operation in 'add-layer' and config.get(host) is None:
     print("Config file 'config.yml' is invalid. '" + host + "' is not specified")
@@ -55,7 +57,10 @@ if config.get(tenant_name) is not None:
     variables['ASSERTS_TENANT_NAME'] = config[tenant_name]
 if config.get(password) is not None:
     variables['ASSERTS_PASSWORD'] = config[password]
-
+if config.get(env) is not None:
+    variables['ASSERTS_ENVIRONMENT'] = config[env]
+if config.get(site) is not None:
+    variables['ASSERTS_SITE'] = config[site]
 
 def update_all_functions():
     # List the functions

--- a/deployment/sample-config.yml
+++ b/deployment/sample-config.yml
@@ -10,6 +10,8 @@ ASSERTS_METRICSTORE_HOST: chief.tsdb.dev.asserts.ai
 # ASSERTS_TENANT and ASSERTS_PASSWORD are optional
 ASSERTS_TENANT: chief
 ASSERTS_PASSWORD: wrong
+ASSERTS_ENVIRONMENT: dev
+ASSERTS_SITE: dev
 
 # Functions can be specified either through a regex pattern or through a list of function names
 # function_name_pattern: Sample.+

--- a/src/lib/LambdaInstanceMetrics.ts
+++ b/src/lib/LambdaInstanceMetrics.ts
@@ -24,7 +24,7 @@ export class LambdaInstanceMetrics {
         asserts_source: string;
         asserts_tenant?: string;
         tenant?: string;
-        asserts_site: string | undefined;
+        asserts_site?: string | undefined;
         asserts_env?: string | undefined;
     };
 
@@ -58,12 +58,16 @@ export class LambdaInstanceMetrics {
         this.labelValues = {
             namespace: "AWS/Lambda",
             instance: hostname() + ":" + process.pid,
-            asserts_source: 'prom-client',
-            asserts_site: this.mapRegionCode(process.env['AWS_REGION'])
+            asserts_source: 'prom-client'
         };
         this.labelValues.function_name = process.env["AWS_LAMBDA_FUNCTION_NAME"];
         this.labelValues.job = process.env["AWS_LAMBDA_FUNCTION_NAME"];
         this.labelValues.version = process.env["AWS_LAMBDA_FUNCTION_VERSION"];
+
+        if (process.env["ASSERTS_SITE"]) {
+            this.labelValues.asserts_site = process.env["ASSERTS_SITE"];
+        }
+
         if (process.env["ASSERTS_ENVIRONMENT"]) {
             this.labelValues.asserts_env = process.env["ASSERTS_ENVIRONMENT"];
         }
@@ -103,20 +107,5 @@ export class LambdaInstanceMetrics {
 
     isNameAndVersionSet(): boolean {
         return !!(this.labelValues.job && this.labelValues.function_name && this.labelValues.version);
-    }
-
-    mapRegionCode(region: string | undefined) {
-        switch (region) {
-            case 'uswest1':
-                return 'us-west-1';
-            case 'uswest2':
-                return 'us-west-2';
-            case 'useast1':
-                return 'us-east-1';
-            case 'useast2':
-                return 'us-east-2';
-            default:
-                return region;
-        }
     }
 }

--- a/tests/unit/LambdaInstanceMetric.test.ts
+++ b/tests/unit/LambdaInstanceMetric.test.ts
@@ -4,7 +4,7 @@ import {mocked} from "jest-mock";
 
 jest.mock('prom-client');
 
-describe("Metrics should have been initialized", () => {
+describe("All Tests", () => {
     beforeEach(() => {
         process.env["AWS_LAMBDA_FUNCTION_MEMORY_SIZE"] = "128";
         process.env["AWS_LAMBDA_FUNCTION_NAME"] = "OrderProcessor";
@@ -27,26 +27,27 @@ describe("Metrics should have been initialized", () => {
         expect(lambdaInstance.labelValues).toBeTruthy();
         expect(lambdaInstance.labelValues.instance).toBeTruthy();
         expect(lambdaInstance.labelValues.namespace).toBe("AWS/Lambda");
-        expect(lambdaInstance.labelValues.asserts_site).toBe("us-west-2");
         expect(lambdaInstance.labelValues.function_name).toBe("OrderProcessor")
         expect(lambdaInstance.labelValues.job).toBe("OrderProcessor")
         expect(lambdaInstance.labelValues.version).toBe("1");
         expect(lambdaInstance.isNameAndVersionSet()).toBe(true);
         expect(lambdaInstance.labelValues.asserts_env).toBeFalsy();
+        expect(lambdaInstance.labelValues.asserts_site).toBeFalsy();
     });
 
     it("Label values are initialised with environment", () => {
         process.env["ASSERTS_ENVIRONMENT"] = "dev";
+        process.env["ASSERTS_SITE"] = "dev";
         const lambdaInstance: LambdaInstanceMetrics = new LambdaInstanceMetrics();
         expect(lambdaInstance.labelValues).toBeTruthy();
         expect(lambdaInstance.labelValues.instance).toBeTruthy();
         expect(lambdaInstance.labelValues.namespace).toBe("AWS/Lambda");
-        expect(lambdaInstance.labelValues.asserts_site).toBe("us-west-2");
         expect(lambdaInstance.labelValues.function_name).toBe("OrderProcessor")
         expect(lambdaInstance.labelValues.job).toBe("OrderProcessor")
         expect(lambdaInstance.labelValues.version).toBe("1");
         expect(lambdaInstance.isNameAndVersionSet()).toBe(true);
         expect(lambdaInstance.labelValues.asserts_env).toBe("dev");
+        expect(lambdaInstance.labelValues.asserts_site).toBe("dev");
     });
 
     it("Function context is not initialised yet", () => {
@@ -152,13 +153,5 @@ describe("Metrics should have been initialized", () => {
         mockIsSet.mockReturnValue(false);
         let result = await metricInstance.getAllMetricsAsText();
         expect(result).toBeNull();
-    })
-
-    it("Transform region code", async () => {
-        expect(LambdaInstanceMetrics.prototype.mapRegionCode('uswest1')).toBe('us-west-1');
-        expect(LambdaInstanceMetrics.prototype.mapRegionCode('uswest2')).toBe('us-west-2');
-        expect(LambdaInstanceMetrics.prototype.mapRegionCode('useast1')).toBe('us-east-1');
-        expect(LambdaInstanceMetrics.prototype.mapRegionCode('useast2')).toBe('us-east-2');
-        expect(LambdaInstanceMetrics.prototype.mapRegionCode('other')).toBe('other');
     })
 });


### PR DESCRIPTION
Env/site would now have to be configured as environment variables for the Lambda layer to emit as part of the metrics.